### PR TITLE
Mouse/touch navigation and view options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "360-component",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "main": "index.js",
   "repository": "https://github.com/pandasuite/360-component.git",

--- a/public/pandasuite.json
+++ b/public/pandasuite.json
@@ -7,7 +7,7 @@
       "fr_FR": "Affiche des images ou vidéos panoramiques à 360° avec navigation gyroscope et tactile, contrôles à l'écran optionnels, rotation automatique, mode VR, et marqueurs points de vue/points d'intérêt."
     }
   },
-  "version": "2.0.0",
+  "version": "2.1.0",
   "main": "",
   "system": {
     "markers": [
@@ -111,11 +111,15 @@
         "params": [
           {
             "id": "transitionSpeed",
-            "name": "Transition (ms)",
-            "locale_name": { "fr_FR": "Transition (ms)" },
+            "name": "Transition duration",
+            "locale_name": { "fr_FR": "Durée de transition" },
             "type": "Integer",
             "value": 1500,
-            "restrict": { "min": 0, "max": 10000, "step": 100 }
+            "restrict": { "min": 0, "max": 10000, "step": 100 },
+            "description": "Camera animation duration in milliseconds (0 = instant).",
+            "locale_description": {
+              "fr_FR": "Durée de l'animation de la caméra en millisecondes (0 = instantané)."
+            }
           }
         ]
       }
@@ -186,8 +190,8 @@
     },
     {
       "id": "isVR",
-      "name": "VR mode (Cardboard)",
-      "locale_name": { "fr_FR": "Mode VR (Cardboard)" },
+      "name": "VR mode",
+      "locale_name": { "fr_FR": "Mode VR" },
       "type": "Boolean",
       "value": false,
       "description": "Add a stereoscopic VR button (split-screen, gyroscope-based).",
@@ -218,6 +222,115 @@
       "description": "Auto-rotation speed in rotations per minute.",
       "locale_description": {
         "fr_FR": "Vitesse de rotation automatique en tours par minute."
+      }
+    },
+    {
+      "id": "mousemove",
+      "name": "Drag to rotate",
+      "locale_name": { "fr_FR": "Glisser pour tourner" },
+      "type": "Boolean",
+      "value": true,
+      "separator": true,
+      "description": "Let the user drag (or swipe) to rotate the view.",
+      "locale_description": {
+        "fr_FR": "Permettre à l'utilisateur de faire glisser (ou balayer) pour tourner la vue."
+      }
+    },
+    {
+      "id": "moveSpeed",
+      "name": "Drag speed",
+      "locale_name": { "fr_FR": "Vitesse de glissement" },
+      "type": "Float",
+      "value": 1,
+      "restrict": { "min": 0.1, "max": 5, "step": 0.1 },
+      "hidden": "!properties.mousemove.value",
+      "description": "Drag rotation speed multiplier (1 = default).",
+      "locale_description": {
+        "fr_FR": "Multiplicateur de vitesse de rotation au glissement (1 = défaut)."
+      }
+    },
+    {
+      "id": "moveInertia",
+      "name": "Inertia",
+      "locale_name": { "fr_FR": "Inertie" },
+      "type": "Float",
+      "value": 0.8,
+      "restrict": { "min": 0, "max": 1, "step": 0.05 },
+      "hidden": "!properties.mousemove.value",
+      "description": "Glide after releasing a drag (0 = stop immediately, 0.8 = default).",
+      "locale_description": {
+        "fr_FR": "Inertie après un glissement (0 = arrêt immédiat, 0.8 = défaut)."
+      }
+    },
+    {
+      "id": "touchmoveTwoFingers",
+      "name": "Two-finger pan",
+      "locale_name": { "fr_FR": "Navigation à deux doigts" },
+      "type": "Boolean",
+      "value": false,
+      "description": "Require two fingers to rotate on touch, so a one-finger swipe scrolls the page.",
+      "locale_description": {
+        "fr_FR": "Exiger deux doigts pour tourner au toucher, afin qu'un balayage à un doigt fasse défiler la page."
+      }
+    },
+    {
+      "id": "mousewheel",
+      "name": "Scroll to zoom",
+      "locale_name": { "fr_FR": "Molette pour zoomer" },
+      "type": "Boolean",
+      "value": true,
+      "description": "Let the user zoom with the mouse wheel.",
+      "locale_description": {
+        "fr_FR": "Permettre à l'utilisateur de zoomer avec la molette."
+      }
+    },
+    {
+      "id": "zoomSpeed",
+      "name": "Zoom speed",
+      "locale_name": { "fr_FR": "Vitesse du zoom" },
+      "type": "Float",
+      "value": 1,
+      "restrict": { "min": 0.1, "max": 5, "step": 0.1 },
+      "hidden": "!properties.mousewheel.value",
+      "description": "Zoom speed multiplier (1 = default).",
+      "locale_description": {
+        "fr_FR": "Multiplicateur de vitesse du zoom (1 = défaut)."
+      }
+    },
+    {
+      "id": "minFov",
+      "name": "Min FOV",
+      "locale_name": { "fr_FR": "FOV min" },
+      "type": "Integer",
+      "value": 30,
+      "separator": true,
+      "restrict": { "min": 1, "max": 90, "step": 1 },
+      "description": "Smallest field of view in degrees — the zoom-in limit (30 = default).",
+      "locale_description": {
+        "fr_FR": "Champ de vision minimal en degrés — limite de zoom avant (30 = défaut)."
+      }
+    },
+    {
+      "id": "maxFov",
+      "name": "Max FOV",
+      "locale_name": { "fr_FR": "FOV max" },
+      "type": "Integer",
+      "value": 90,
+      "restrict": { "min": 30, "max": 120, "step": 1 },
+      "description": "Largest field of view in degrees — the zoom-out limit (90 = default).",
+      "locale_description": {
+        "fr_FR": "Champ de vision maximal en degrés — limite de zoom arrière (90 = défaut)."
+      }
+    },
+    {
+      "id": "fisheye",
+      "name": "Fisheye effect",
+      "locale_name": { "fr_FR": "Effet fisheye" },
+      "type": "Boolean",
+      "value": false,
+      "description": "Apply a fisheye (barrel) distortion to the view.",
+      "locale_description": {
+        "fr_FR": "Appliquer une distorsion fisheye (barillet) à la vue."
       }
     },
     {

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import { AutorotatePlugin } from '@photo-sphere-viewer/autorotate-plugin';
 import { StereoPlugin } from '@photo-sphere-viewer/stereo-plugin';
 import { MarkersPlugin } from '@photo-sphere-viewer/markers-plugin';
 import { IMG_SIZES, pickImageSize, imageMarkerSize } from './responsive.js';
+import { viewerOptions } from './viewerOptions.js';
 
 import '@photo-sphere-viewer/core/index.css';
 import '@photo-sphere-viewer/markers-plugin/index.css';
@@ -471,6 +472,10 @@ function applyOptions() {
     container.classList.toggle('ps-hide-controls', !properties.showControls);
   }
 
+  // Navigation/view options apply live and aren't navbar-toggleable (no user-toggle
+  // to clobber), so re-assert them unconditionally; setOptions is idempotent.
+  viewer.setOptions(viewerOptions(properties));
+
   // Mute, gyroscope and auto-rotation are also toggleable live from the navbar, so
   // re-assert each only when its panel value changed (vs appliedProps) — otherwise an
   // unrelated update would revert the user's live toggle.
@@ -616,6 +621,8 @@ function createViewer(url) {
     canvasBackground: '#000000',
     loadingTxt: '',
     rendererParameters: { preserveDrawingBuffer: true },
+    // Navigation/view options up-front so the first paint respects fisheye/min-maxFov.
+    ...viewerOptions(properties),
   };
   // Aim PSV at the default view up-front so the very first rendered frame is
   // correct (PSV applies defaultYaw/Pitch/ZoomLvl during the initial load).

--- a/src/viewerOptions.js
+++ b/src/viewerOptions.js
@@ -1,0 +1,33 @@
+// Map PandaSuite properties to the Photo-Sphere-Viewer navigation/view options.
+// Pure (no PSV/DOM deps) so the default-coalescing — the error-prone part — is
+// unit-tested in isolation. Every default equals PSV's own default, so a project
+// that sets none of these behaves exactly as before.
+//
+// All nine are live-applicable via viewer.setOptions (none are READONLY_OPTIONS),
+// so the result is spread into the initial config AND re-applied in applyOptions.
+const num = (v, def) => (v == null ? def : Number(v));
+
+export function viewerOptions(p = {}) {
+  // PSV's fovToZoomLevel divides by (maxFov - minFov), so equal or inverted bounds
+  // would yield NaN/negative zoom. Normalise to an ordered pair with a ≥1° gap —
+  // this also quietly fixes a min/max typo rather than breaking zoom.
+  let minFov = num(p.minFov, 30);
+  let maxFov = num(p.maxFov, 90);
+  if (minFov > maxFov) { [minFov, maxFov] = [maxFov, minFov]; }
+  if (minFov === maxFov) { maxFov = minFov + 1; }
+
+  return {
+    // Booleans whose PSV default is true: only off when explicitly false.
+    mousemove: p.mousemove !== false,
+    mousewheel: p.mousewheel !== false,
+    // Booleans whose PSV default is false.
+    touchmoveTwoFingers: !!p.touchmoveTwoFingers,
+    fisheye: !!p.fisheye,
+    // Numbers (== null keeps an explicit 0, e.g. zero inertia, from the default).
+    moveSpeed: num(p.moveSpeed, 1),
+    zoomSpeed: num(p.zoomSpeed, 1),
+    moveInertia: num(p.moveInertia, 0.8),
+    minFov,
+    maxFov,
+  };
+}

--- a/src/viewerOptions.test.js
+++ b/src/viewerOptions.test.js
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { viewerOptions } from './viewerOptions.js';
+
+test('empty properties yield PSV defaults (current behavior preserved)', () => {
+  assert.deepEqual(viewerOptions({}), {
+    mousemove: true,
+    moveSpeed: 1,
+    moveInertia: 0.8,
+    touchmoveTwoFingers: false,
+    mousewheel: true,
+    zoomSpeed: 1,
+    minFov: 30,
+    maxFov: 90,
+    fisheye: false,
+  });
+});
+
+test('undefined argument is treated as empty', () => {
+  assert.equal(viewerOptions().mousemove, true);
+  assert.equal(viewerOptions().moveSpeed, 1);
+});
+
+test('booleans defaulting to true are only false when explicitly false', () => {
+  assert.equal(viewerOptions({ mousemove: false }).mousemove, false);
+  assert.equal(viewerOptions({ mousewheel: false }).mousewheel, false);
+  // any non-false (incl. undefined) stays true
+  assert.equal(viewerOptions({ mousemove: undefined }).mousemove, true);
+});
+
+test('booleans defaulting to false coerce truthy/falsy', () => {
+  assert.equal(viewerOptions({ touchmoveTwoFingers: true }).touchmoveTwoFingers, true);
+  assert.equal(viewerOptions({ fisheye: true }).fisheye, true);
+  assert.equal(viewerOptions({ touchmoveTwoFingers: false }).touchmoveTwoFingers, false);
+});
+
+test('numeric options are coerced from their values', () => {
+  const o = viewerOptions({
+    moveSpeed: 2, zoomSpeed: 0.5, moveInertia: 0.3, minFov: 20, maxFov: 100,
+  });
+  assert.equal(o.moveSpeed, 2);
+  assert.equal(o.zoomSpeed, 0.5);
+  assert.equal(o.moveInertia, 0.3);
+  assert.equal(o.minFov, 20);
+  assert.equal(o.maxFov, 100);
+});
+
+test('explicit 0 is kept, not replaced by the default', () => {
+  // 0 inertia = stop immediately; must not fall back to 0.8
+  assert.equal(viewerOptions({ moveInertia: 0 }).moveInertia, 0);
+});
+
+test('equal FOV bounds are separated by 1° (PSV divides by maxFov - minFov)', () => {
+  const o = viewerOptions({ minFov: 60, maxFov: 60 });
+  assert.equal(o.minFov, 60);
+  assert.equal(o.maxFov, 61);
+});
+
+test('inverted FOV bounds are swapped into order', () => {
+  const o = viewerOptions({ minFov: 90, maxFov: 30 });
+  assert.equal(o.minFov, 30);
+  assert.equal(o.maxFov, 90);
+});
+
+test('valid FOV bounds pass through unchanged', () => {
+  const o = viewerOptions({ minFov: 45, maxFov: 85 });
+  assert.equal(o.minFov, 45);
+  assert.equal(o.maxFov, 85);
+});


### PR DESCRIPTION
Exposes Photo-Sphere-Viewer's navigation and view options as component properties, applied **live** via `setOptions` (no viewer rebuild).

### Navigation
- **Drag to rotate** → drag speed, inertia
- **Two-finger pan** — a one-finger swipe scrolls the host page instead
- **Scroll to zoom** → zoom speed

### View
- **Min/Max FOV** — zoom-in / zoom-out limits
- **Fisheye**

### Notes
- Defaults equal PSV's own, so existing projects are unaffected until a value changes.
- The property→option mapping is a pure, unit-tested helper (`src/viewerOptions.js`); spread into the initial config and re-applied on update.
- Property names kept short and parenthesis-free, with qualifiers in descriptions (a couple of pre-existing names tidied too).
- Additive → **2.1.0** (minor).