### PR TITLE
[codex] Trigger markers when reaching viewpoints

### DIFF
--- a/public/pandasuite.json
+++ b/public/pandasuite.json
@@ -127,12 +127,22 @@
     "events": [
       {
         "id": "triggerMarker",
-        "name": "Marker tapped",
-        "locale_name": { "fr_FR": "Marqueur tapé" },
+        "name": "Hotspot tapped",
+        "locale_name": { "fr_FR": "Point d'intérêt tapé" },
         "hidden": "marker.type != 'hotspot'",
         "description": "Fires when a hotspot marker is tapped.",
         "locale_description": {
           "fr_FR": "Se déclenche quand un point d'intérêt est tapé."
+        }
+      },
+      {
+        "id": "triggerMarker",
+        "name": "Viewpoint reached",
+        "locale_name": { "fr_FR": "Point de vue atteint" },
+        "hidden": "marker.type != 'viewpoint'",
+        "description": "Fires when the camera reaches a viewpoint marker.",
+        "locale_description": {
+          "fr_FR": "Se déclenche quand la caméra atteint un point de vue."
         }
       }
     ],

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import { StereoPlugin } from '@photo-sphere-viewer/stereo-plugin';
 import { MarkersPlugin } from '@photo-sphere-viewer/markers-plugin';
 import { IMG_SIZES, pickImageSize, imageMarkerSize } from './responsive.js';
 import { viewerOptions } from './viewerOptions.js';
+import { detectViewpoint } from './viewpointDetector.js';
 
 import '@photo-sphere-viewer/core/index.css';
 import '@photo-sphere-viewer/markers-plugin/index.css';
@@ -33,6 +34,9 @@ let addingHotspot = false;
 let hintEl = null;
 let selectedViewpointId = null;
 let markersGen = 0;
+let viewerReady = false;
+let activeViewpointId = null;
+let viewpointDetectionFrame = null;
 // Last autorotate speed pushed to the plugin; a running autorotate keeps the roll
 // speed captured at start(), so we only restart it when this value changes.
 let appliedAutoRotateSpeed = null;
@@ -261,6 +265,10 @@ async function applyMarkers() {
   const gen = ++markersGen;
   const list = markers || [];
   viewpoints = list.filter((m) => m.type === 'viewpoint');
+  if (activeViewpointId && !viewpoints.some((m) => String(m.id) === activeViewpointId)) {
+    activeViewpointId = null;
+  }
+  scheduleViewpointDetection();
   const hotspots = list.filter((m) => m.type === 'hotspot');
   // Image hotspots resolve asynchronously (preload for ratio); dots resolve
   // synchronously. Build them all, then set in one pass.
@@ -375,6 +383,58 @@ function updateSelectedViewpoint(markerId) {
   }
   PandaBridge.send(PandaBridge.UPDATED, { markers: marker });
   applyMarkers();
+}
+
+function currentViewpointFrame() {
+  if (!viewer) {
+    return null;
+  }
+  const pos = viewer.getPosition();
+  return {
+    yaw: normDeg(rad2deg(pos.yaw)),
+    pitch: rad2deg(pos.pitch),
+    zoom: viewer.getZoomLevel(),
+  };
+}
+
+function viewpointDetectionOptions() {
+  const size = viewer && viewer.getSize();
+  return {
+    minFov: viewer && viewer.config && viewer.config.minFov,
+    maxFov: viewer && viewer.config && viewer.config.maxFov,
+    aspect: size && size.height ? size.width / size.height : 1,
+  };
+}
+
+function runViewpointDetection() {
+  viewpointDetectionFrame = null;
+  if (!viewer || !viewerReady || !viewpoints.length) {
+    activeViewpointId = null;
+    return;
+  }
+  const stereo = viewer.getPlugin(StereoPlugin);
+  if (stereo && stereo.isEnabled()) {
+    return;
+  }
+
+  const result = detectViewpoint(
+    viewpoints,
+    currentViewpointFrame(),
+    { activeId: activeViewpointId },
+    viewpointDetectionOptions(),
+  );
+  activeViewpointId = result.activeId;
+  if (result.triggerId) {
+    PandaBridge.send(PandaBridge.TRIGGER_MARKER, result.triggerId);
+  }
+}
+
+function scheduleViewpointDetection() {
+  if (!viewer || viewpointDetectionFrame != null) {
+    return;
+  }
+  const raf = window.requestAnimationFrame || ((cb) => window.setTimeout(cb, 0));
+  viewpointDetectionFrame = raf(runViewpointDetection);
 }
 
 function startGyro() {
@@ -517,6 +577,11 @@ function wireViewer() {
     PandaBridge.send(PandaBridge.TRIGGER_MARKER, (marker.data && marker.data.id) || marker.id);
   });
 
+  const scheduleDetection = () => scheduleViewpointDetection();
+  viewer.addEventListener('position-updated', scheduleDetection);
+  viewer.addEventListener('zoom-updated', scheduleDetection);
+  viewer.addEventListener('size-updated', scheduleDetection);
+
   // Keep autorotate in sync with the gyroscope, which toggles asynchronously (after
   // its support/permission check) and from the navbar button. Gyro on → autorotate
   // yields to it; gyro off by the user → autorotate resumes; gyro off because a
@@ -548,8 +613,10 @@ function wireViewer() {
   viewer.addEventListener(
     'ready',
     () => {
+      viewerReady = true;
       PandaBridge.send(PandaBridge.INITIALIZED);
       applyOptions();
+      scheduleViewpointDetection();
     },
     { once: true },
   );
@@ -605,6 +672,8 @@ function defaultViewpoint() {
 function createViewer(url) {
   currentUrl = url;
   viewerIsVideo = isVideo;
+  viewerReady = false;
+  activeViewpointId = null;
   // Fresh viewer: forget what was applied so applyOptions re-asserts every option.
   appliedProps = {};
   const config = {

--- a/src/viewpointDetector.js
+++ b/src/viewpointDetector.js
@@ -1,0 +1,123 @@
+const DEFAULT_ENTER_RATIO = 0.72;
+const DEFAULT_EXIT_RATIO = 0.55;
+
+const toNumber = (value, fallback) => {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+const clamp = (n, min, max) => Math.max(min, Math.min(max, n));
+
+function fovBounds(options = {}) {
+  let minFov = toNumber(options.minFov, 30);
+  let maxFov = toNumber(options.maxFov, 90);
+  if (minFov > maxFov) {
+    [minFov, maxFov] = [maxFov, minFov];
+  }
+  if (minFov === maxFov) {
+    maxFov = minFov + 1;
+  }
+  return { minFov, maxFov };
+}
+
+export function zoomLevelToFov(level, options = {}) {
+  const { minFov, maxFov } = fovBounds(options);
+  const zoom = clamp(toNumber(level, 50), 0, 100);
+  return maxFov + (zoom / 100) * (minFov - maxFov);
+}
+
+export function horizontalFov(verticalFov, aspect = 1) {
+  const safeAspect = Math.max(toNumber(aspect, 1), 0.01);
+  const radians = (verticalFov * Math.PI) / 180;
+  return (2 * Math.atan(Math.tan(radians / 2) * safeAspect) * 180) / Math.PI;
+}
+
+export function shortestArcDeg(from, to) {
+  return ((to - from + 540) % 360) - 180;
+}
+
+function centeredOverlap(delta, currentSpan, targetSpan) {
+  if (currentSpan <= 0 || targetSpan <= 0) {
+    return 0;
+  }
+  const currentMin = -currentSpan / 2;
+  const currentMax = currentSpan / 2;
+  const targetMin = delta - targetSpan / 2;
+  const targetMax = delta + targetSpan / 2;
+  return Math.max(0, Math.min(currentMax, targetMax) - Math.max(currentMin, targetMin));
+}
+
+function overlapScore(delta, currentSpan, targetSpan) {
+  const overlap = centeredOverlap(delta, currentSpan, targetSpan);
+  return Math.min(overlap / currentSpan, overlap / targetSpan);
+}
+
+function fovFrame(view, options = {}) {
+  const zoom = toNumber(view.zoom, 50);
+  const vFov = zoomLevelToFov(zoom, options);
+  return {
+    yaw: toNumber(view.yaw, 0),
+    pitch: toNumber(view.pitch, 0),
+    hFov: horizontalFov(vFov, options.aspect),
+    vFov,
+  };
+}
+
+export function viewpointScore(viewpoint, current, options = {}) {
+  if (!viewpoint || viewpoint.type !== 'viewpoint' || viewpoint.id == null || !current) {
+    return 0;
+  }
+
+  const currentFrame = fovFrame(current, options);
+  const targetFrame = fovFrame(
+    {
+      yaw: viewpoint.yaw,
+      pitch: viewpoint.pitch,
+      zoom: viewpoint.zoom == null ? current.zoom : viewpoint.zoom,
+    },
+    options,
+  );
+
+  const yawDelta = shortestArcDeg(currentFrame.yaw, targetFrame.yaw);
+  const pitchDelta = targetFrame.pitch - currentFrame.pitch;
+  return Math.min(
+    overlapScore(yawDelta, currentFrame.hFov, targetFrame.hFov),
+    overlapScore(pitchDelta, currentFrame.vFov, targetFrame.vFov),
+  );
+}
+
+function bestViewpoint(viewpoints, current, options, ratio) {
+  let best = null;
+  let bestScore = -1;
+
+  (viewpoints || []).forEach((viewpoint) => {
+    const score = viewpointScore(viewpoint, current, options);
+    if (score >= ratio && score > bestScore) {
+      best = viewpoint;
+      bestScore = score;
+    }
+  });
+
+  return best;
+}
+
+export function detectViewpoint(viewpoints, current, state = {}, options = {}) {
+  const activeId = state && state.activeId != null ? String(state.activeId) : null;
+  const enterRatio = toNumber(options.enterRatio, DEFAULT_ENTER_RATIO);
+  const exitRatio = toNumber(options.exitRatio, DEFAULT_EXIT_RATIO);
+
+  if (activeId) {
+    const active = (viewpoints || []).find((m) => String(m.id) === activeId);
+    if (active && viewpointScore(active, current, options) >= exitRatio) {
+      return { activeId, triggerId: null };
+    }
+  }
+
+  const match = bestViewpoint(viewpoints, current, options, enterRatio);
+  if (match) {
+    const id = String(match.id);
+    return { activeId: id, triggerId: id };
+  }
+
+  return { activeId: null, triggerId: null };
+}

--- a/src/viewpointDetector.test.js
+++ b/src/viewpointDetector.test.js
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { detectViewpoint } from './viewpointDetector.js';
+
+const options = { minFov: 30, maxFov: 90, aspect: 16 / 9 };
+
+test('detectViewpoint triggers a matching viewpoint on first evaluation', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: 12, pitch: -3, zoom: 40 }],
+    { yaw: 12, pitch: -3, zoom: 40 },
+    { activeId: null },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: 'view-1', triggerId: 'view-1' });
+});
+
+test('detectViewpoint does not retrigger while the same viewpoint remains active', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: 12, pitch: -3, zoom: 40 }],
+    { yaw: 12, pitch: -3, zoom: 40 },
+    { activeId: 'view-1' },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: 'view-1', triggerId: null });
+});
+
+test('detectViewpoint requires the zoom framing to be close', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: 0, pitch: 0, zoom: 100 }],
+    { yaw: 0, pitch: 0, zoom: 0 },
+    { activeId: null },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: null, triggerId: null });
+});
+
+test('detectViewpoint applies zoom framing when marker zoom is serialized', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: 0, pitch: 0, zoom: '100' }],
+    { yaw: 0, pitch: 0, zoom: 0 },
+    { activeId: null },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: null, triggerId: null });
+});
+
+test('detectViewpoint adapts horizontal tolerance to the component aspect ratio', () => {
+  const viewpoints = [{ id: 'view-1', type: 'viewpoint', yaw: 25, pitch: 0, zoom: 50 }];
+  const current = { yaw: 0, pitch: 0, zoom: 50 };
+
+  assert.deepEqual(
+    detectViewpoint(viewpoints, current, { activeId: null }, { ...options, aspect: 1 }),
+    { activeId: null, triggerId: null },
+  );
+  assert.deepEqual(
+    detectViewpoint(viewpoints, current, { activeId: null }, { ...options, aspect: 2 }),
+    { activeId: 'view-1', triggerId: 'view-1' },
+  );
+});
+
+test('detectViewpoint handles yaw wrap around the panorama seam', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: -179, pitch: 0, zoom: 50 }],
+    { yaw: 179, pitch: 0, zoom: 50 },
+    { activeId: null },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: 'view-1', triggerId: 'view-1' });
+});
+
+test('detectViewpoint picks the best matching viewpoint only', () => {
+  const result = detectViewpoint(
+    [
+      { id: 'near', type: 'viewpoint', yaw: 8, pitch: 0, zoom: 50 },
+      { id: 'exact', type: 'viewpoint', yaw: 0, pitch: 0, zoom: 50 },
+    ],
+    { yaw: 0, pitch: 0, zoom: 50 },
+    { activeId: null },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: 'exact', triggerId: 'exact' });
+});
+
+test('detectViewpoint clears the active viewpoint after leaving its exit threshold', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: 0, pitch: 0, zoom: 50 }],
+    { yaw: 150, pitch: 0, zoom: 50 },
+    { activeId: 'view-1' },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: null, triggerId: null });
+});
+
+test('detectViewpoint treats viewpoints without zoom as position-only markers', () => {
+  const result = detectViewpoint(
+    [{ id: 'view-1', type: 'viewpoint', yaw: 0, pitch: 0 }],
+    { yaw: 0, pitch: 0, zoom: 0 },
+    { activeId: null },
+    options,
+  );
+
+  assert.deepEqual(result, { activeId: 'view-1', triggerId: 'view-1' });
+});


### PR DESCRIPTION
## Summary
- trigger the existing marker event when the camera reaches a viewpoint
- add a small FOV/aspect-aware viewpoint detector with unit tests
- split the manifest marker event label into hotspot/viewpoint variants for the upcoming Studio support

## Validation
- `python3 -m json.tool public/pandasuite.json > /dev/null`
- `git diff --check`
- `yarn test`
- `yarn build`

## Note
The two `triggerMarker` definitions are intended for the new Studio logic that resolves system events per marker type. Until that authoring change ships, the current Studio may only read the first definition.